### PR TITLE
core: Create `getInputList` utility

### DIFF
--- a/packages/core/__tests__/core.test.ts
+++ b/packages/core/__tests__/core.test.ts
@@ -19,6 +19,13 @@ const testEnvVars = {
   'INPUT_SPECIAL_CHARS_\'\t"\\': '\'\t"\\ response ',
   INPUT_MULTIPLE_SPACES_VARIABLE: 'I have multiple spaces',
 
+  // Set input lists
+  /**
+   * why `'\n'` instead of an `[]`: https://github.com/actions/cache/issues/44#issuecomment-549399196
+   * the FR for this feature + tracking of the previous one: https://github.com/actions/toolkit/issues/184
+   */
+  INPUT_MY_INPUT_LIST: 'val1\nval2\nval3',
+
   // Save inputs
   STATE_TEST_1: 'state_val'
 }
@@ -97,6 +104,10 @@ describe('@actions/core', () => {
     expect(core.getInput('multiple spaces variable')).toBe(
       'I have multiple spaces'
     )
+  })
+
+  it('getInputList works', () => {
+    expect(core.getInputList('my input list')).toEqual(['val1', 'val2', 'val3'])
   })
 
   it('setOutput produces the correct command', () => {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -75,6 +75,21 @@ export function getInput(name: string, options?: InputOptions): string {
 }
 
 /**
+ * Gets the values of an input list.  Each value is also trimmed.
+ *
+ * @param     name     name of the input list to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ */
+export function getInputList(name: string, options?: InputOptions): string[] {
+  const inputs: string[] = getInput(name, options)
+    .split('\n')
+    .filter(x => x !== '')
+
+  return inputs
+}
+
+/**
  * Sets the value of an output.
  *
  * @param     name     name of the output to set

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -80,6 +80,11 @@ export function getInput(name: string, options?: InputOptions): string {
  * @param     name     name of the input list to get
  * @param     options  optional. See InputOptions.
  * @returns   string[]
+ *
+ * See also:
+ *
+ * why `'\n'` instead of an `[]`: https://github.com/actions/cache/issues/44#issuecomment-549399196
+ * the FR for this feature + tracking of the previous one: https://github.com/actions/toolkit/issues/184
  */
 export function getInputList(name: string, options?: InputOptions): string[] {
   const inputs: string[] = getInput(name, options)


### PR DESCRIPTION
Would fix https://github.com/actions/toolkit/issues/184,

but there's another issue - https://github.com/actions/cache/issues/44:
an input list should use arrays instead of strings,
separated by newlines ('\n').